### PR TITLE
Optimized Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,33 @@
-FROM python:3
+FROM python:3-alpine
 
 WORKDIR /usr/src/shynet
-
-RUN apt update
-RUN apt install -y gettext
-
-# URL from https://github.com/shlinkio/shlink/issues/596 :)
-RUN curl "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=G4Lm0C60yJsnkdPi&suffix=tar.gz" | tar -xvz -C /tmp
-RUN curl "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=G4Lm0C60yJsnkdPi&suffix=tar.gz" | tar -xvz -C /tmp
-RUN mv /tmp/GeoLite2*/*.mmdb /etc
-
-RUN pip install pipenv
-COPY Pipfile.lock ./
-COPY Pipfile ./
-RUN pipenv install --system --deploy
-
+COPY Pipfile.lock Pipfile ./
 COPY shynet .
-RUN python manage.py collectstatic --noinput
-RUN python manage.py compilemessages
+
+RUN apk update && \
+	apk add gettext curl bash && \
+	# URL from https://github.com/shlinkio/shlink/issues/596 :)
+	curl "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=G4Lm0C60yJsnkdPi&suffix=tar.gz" | tar -xvz -C /tmp && \
+	curl "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=G4Lm0C60yJsnkdPi&suffix=tar.gz" | tar -xvz -C /tmp && \
+	mv /tmp/GeoLite2*/*.mmdb /etc && \
+	apk del curl && \
+	apk add --no-cache postgresql-libs && \
+	apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
+	pip install pipenv && \
+	pipenv install --system --deploy && \
+	apk --purge del .build-deps && \
+	rm -rf /var/lib/apt/lists/* && \
+	rm /var/cache/apk/*
 
 ARG GF_UID="500"
 ARG GF_GID="500"
 
 # add group & user
-RUN groupadd -r -g $GF_GID appgroup && \
-   useradd appuser -r -u $GF_UID -g appgroup
+RUN python manage.py collectstatic --noinput && \
+	python manage.py compilemessages && \
+	addgroup --system -g $GF_GID appgroup && \
+	adduser appuser --system --uid $GF_UID -G appgroup
 
 USER appuser
-
 EXPOSE 8080
-
 ENTRYPOINT [ "./entrypoint.sh" ]


### PR DESCRIPTION
Changed to Alpine
Changed shell to sh from bash due to Alpine
Optimized Docker Layers

Changes put the new docker image at 336.4 MB from previously 1.3 GB, and also lowers the number of layers needed. Tested as having same functionality both on init and on re-run.

Closes #20 