### PR TITLE
FIX: Quote variable to allow whitespaces

### DIFF
--- a/shynet/startup_checks.sh
+++ b/shynet/startup_checks.sh
@@ -35,7 +35,7 @@ fi
 if [[ -n $SHYNET_WHITELABEL && ${sanity_results[3]} == True ]]; then
   echo "Setting whitelabel..."
   {
-    ./manage.py whitelabel $SHYNET_WHITELABEL && echo "Whitelabel set! Whitelabel: $SHYNET_WHITELABEL"
+    ./manage.py whitelabel "$SHYNET_WHITELABEL" && echo "Whitelabel set! Whitelabel: $SHYNET_WHITELABEL"
   } || {
     echo "Failed to set whitelabel, exiting" & exit 1
   }


### PR DESCRIPTION
The `SHYNET_WHITELABEL` variable was being used without quotes,
which breaks the commnand if it contains whitespaces