### PR TITLE
Added control to toggle the display of version information

### DIFF
--- a/TEMPLATE.env
+++ b/TEMPLATE.env
@@ -58,6 +58,9 @@ PERFORM_CHECKS_AND_SETUP=True
 # The port that Shynet should bind to. Don't set this if you're deploying on Heroku.
 PORT=8080
 
+# Set to "False" if you do not want the version to be displayed on the frontend.
+SHOW_SHYNET_VERSION=True
+
 # Redis, queue, and parellization settings; not necessary for single-instance deployments.
 # Don't uncomment these unless you know what you are doing!
 # NUM_WORKERS=1

--- a/app.json
+++ b/app.json
@@ -1,13 +1,13 @@
 {
   "name": "Shynet",
-  "description":"Modern, privacy-friendly, and detailed web analytics that works without cookies or JS.",
-    "keywords":[
-      "app.json",
-      "shynet",
-      "heroku",
-      "analytics",
-      "privacy",
-      "friendly"
+  "description": "Modern, privacy-friendly, and detailed web analytics that works without cookies or JS.",
+  "keywords": [
+    "app.json",
+    "shynet",
+    "heroku",
+    "analytics",
+    "privacy",
+    "friendly"
   ],
   "website": "https://github.com/milesmcc/shynet",
   "repository": "https://github.com/milesmcc/shynet",
@@ -115,6 +115,11 @@
     },
     "PERFORM_CHECKS_AND_SETUP": {
       "description": "Whether to perform checks and setup at startup. Recommended value is 'True' for Heroku users.",
+      "value": "True",
+      "required": false
+    },
+    "SHOW_SHYNET_VERSION": {
+      "description": "Set to 'False' if you do not want the version to be displayed on the frontend.",
       "value": "True",
       "required": false
     }

--- a/shynet/dashboard/templatetags/helpers.py
+++ b/shynet/dashboard/templatetags/helpers.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
 
+import os
 import flag
 import pycountry
 from django import template
@@ -84,7 +85,8 @@ def percent_change_display(start, end):
 
 @register.inclusion_tag("dashboard/includes/sidebar_footer.html")
 def sidebar_footer():
-    return {"version": settings.VERSION}
+    return {"version": "" if settings.SHOW_SHYNET_VERSION
+            else settings.VERSION}
 
 
 @register.inclusion_tag("dashboard/includes/stat_comparison.html")

--- a/shynet/dashboard/templatetags/helpers.py
+++ b/shynet/dashboard/templatetags/helpers.py
@@ -1,6 +1,5 @@
 from urllib.parse import urlparse
 
-import os
 import flag
 import pycountry
 from django import template

--- a/shynet/shynet/settings.py
+++ b/shynet/shynet/settings.py
@@ -315,3 +315,6 @@ SCRIPT_HEARTBEAT_FREQUENCY = int(os.getenv("SCRIPT_HEARTBEAT_FREQUENCY", "5000")
 # How much time can elapse between requests from the same user before a new
 # session is created, in seconds?
 SESSION_MEMORY_TIMEOUT = int(os.getenv("SESSION_MEMORY_TIMEOUT", "1800"))
+
+# Should the Shynet version information be displayed?
+SHOW_SHYNET_VERSION = os.getenv("SHOW_SHYNET_VERSION", "True") == "True"


### PR DESCRIPTION
Addressed #72 by adding the `SHOW_SHYNET_VERSION` variable to `TEMPLATE.env`, `shynet/settings.py` and `app.json`. 

Added comments to demonstrate usage. Uses the environment variable to manipulate the display of the version string in `shynet/dashboard/templates/dashboard/includes/sidebar_footer.html` as passed by `shynet/dashboard/templatetags/helpers.py`.