### PR TITLE
Show hourly chart when date range is 1 day

### DIFF
--- a/shynet/core/models.py
+++ b/shynet/core/models.py
@@ -207,6 +207,7 @@ class Service(models.Model):
         # Show hourly chart for date ranges of 3 days or less, otherwise daily chart
         if (end_time - start_time).days < 3:
             session_chart_tooltip_format = "MM/dd HH:mm"
+            session_chart_granularity = "hourly"
             session_chart_data = {
                 k["hour"]: k["count"]
                 for k in sessions.annotate(hour=TruncHour("start_time"))
@@ -220,6 +221,7 @@ class Service(models.Model):
                     session_chart_data[hour] = 0 if hour <= tz_now else None
         else:
             session_chart_tooltip_format = "MMM d"
+            session_chart_granularity = "daily"
             session_chart_data = {
                 k["date"]: k["count"]
                 for k in sessions.annotate(date=TruncDate("start_time"))
@@ -259,6 +261,7 @@ class Service(models.Model):
                 ]
             ),
             "session_chart_tooltip_format": session_chart_tooltip_format,
+            "session_chart_granularity": session_chart_granularity,
             "online": True,
         }
 

--- a/shynet/core/models.py
+++ b/shynet/core/models.py
@@ -204,7 +204,8 @@ class Service(models.Model):
         if session_count == 0:
             avg_session_duration = None
 
-        if end_time.day == start_time.day:
+        # Show hourly chart for date ranges of 3 days or less, otherwise daily chart
+        if end_time.day <= start_time.day + 2:
             session_chart_tooltip_format = "MM/dd HH:mm"
             session_chart_data = {
                 k["hour"]: k["count"]

--- a/shynet/core/models.py
+++ b/shynet/core/models.py
@@ -205,7 +205,7 @@ class Service(models.Model):
             avg_session_duration = None
 
         # Show hourly chart for date ranges of 3 days or less, otherwise daily chart
-        if end_time.day <= start_time.day + 2:
+        if (end_time - start_time).days <= 3:
             session_chart_tooltip_format = "MM/dd HH:mm"
             session_chart_data = {
                 k["hour"]: k["count"]

--- a/shynet/core/models.py
+++ b/shynet/core/models.py
@@ -205,7 +205,7 @@ class Service(models.Model):
             avg_session_duration = None
 
         # Show hourly chart for date ranges of 3 days or less, otherwise daily chart
-        if (end_time - start_time).days <= 3:
+        if (end_time - start_time).days < 3:
             session_chart_tooltip_format = "MM/dd HH:mm"
             session_chart_data = {
                 k["hour"]: k["count"]
@@ -214,10 +214,10 @@ class Service(models.Model):
                 .annotate(count=models.Count("uuid"))
                 .order_by("hour")
             }
-            for hour_offset in range(int((end_time - start_time).seconds / 3600) + 1):
+            for hour_offset in range(int((end_time - start_time).total_seconds() / 3600) + 1):
                 hour = (start_time + timezone.timedelta(hours=hour_offset))
                 if hour not in session_chart_data:
-                    session_chart_data[hour] = 0 if hour < tz_now else None
+                    session_chart_data[hour] = 0 if hour <= tz_now else None
         else:
             session_chart_tooltip_format = "MMM d"
             session_chart_data = {
@@ -230,7 +230,7 @@ class Service(models.Model):
             for day_offset in range((end_time - start_time).days + 1):
                 day = (start_time + timezone.timedelta(days=day_offset)).date()
                 if day not in session_chart_data:
-                    session_chart_data[day] = 0 if day < tz_now.date() else None
+                    session_chart_data[day] = 0 if day <= tz_now.date() else None
 
         return {
             "currently_online": currently_online,

--- a/shynet/dashboard/templates/dashboard/includes/service_overview.html
+++ b/shynet/dashboard/templates/dashboard/includes/service_overview.html
@@ -51,7 +51,7 @@
     </div>
     <hr class="sep h-4">
     <div style="bottom: -1px;">
-        {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data sparkline=True height=100 name=object.uuid %}
+        {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data sparkline=True height=100 name=object.uuid tooltip_format=stats.session_chart_tooltip_format %}
     </div>
     {% endwith %}
 </a>

--- a/shynet/dashboard/templates/dashboard/includes/service_overview.html
+++ b/shynet/dashboard/templates/dashboard/includes/service_overview.html
@@ -51,7 +51,7 @@
     </div>
     <hr class="sep h-4">
     <div style="bottom: -1px;">
-        {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data sparkline=True height=100 name=object.uuid tooltip_format=stats.session_chart_tooltip_format %}
+        {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data sparkline=True height=100 name=object.uuid tooltip_format=stats.session_chart_tooltip_format granularity=stats.session_chart_granularity %}
     </div>
     {% endwith %}
 </a>

--- a/shynet/dashboard/templates/dashboard/includes/time_chart.html
+++ b/shynet/dashboard/templates/dashboard/includes/time_chart.html
@@ -6,6 +6,9 @@
         },
         tooltip: {
             shared: false,
+            x: {
+                format: '{{tooltip_format|default:"MMM d"}}',
+            },
         },
         colors: ["#805AD5"],
         chart: {
@@ -63,6 +66,9 @@
         },
         xaxis: {
             type: "datetime",
+            labels: {
+                datetimeUTC: false
+            },
         },
         stroke: {
             width: 1.5,

--- a/shynet/dashboard/templates/dashboard/includes/time_chart.html
+++ b/shynet/dashboard/templates/dashboard/includes/time_chart.html
@@ -37,6 +37,14 @@
                     stops: [0, 75, 100]
                 },
             },
+            {% if granularity == "daily" and click_zoom %}
+            events: {
+                markerClick: function(event, chartContext, { seriesIndex, dataPointIndex, w: {config}}) {
+                    const day = config.series[seriesIndex].data[dataPointIndex].x
+                    window.location.href = `?startDate=${day}&endDate=${day}`
+                },
+            },
+            {% endif %}
         },
         grid: {
             padding: {

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -86,7 +86,7 @@
     {% endwith %}
 </div>
 <div class="card ~neutral !low py-0 mb-6">
-    {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data tooltip_format=stats.session_chart_tooltip_format %}
+    {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data tooltip_format=stats.session_chart_tooltip_format granularity=stats.session_chart_granularity click_zoom=True %}
 </div>
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
     <div class="card ~neutral !low limited-height py-2">

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -86,7 +86,7 @@
     {% endwith %}
 </div>
 <div class="card ~neutral !low py-0 mb-6">
-    {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data %}
+    {% include 'dashboard/includes/time_chart.html' with data=stats.session_chart_data tooltip_format=stats.session_chart_tooltip_format %}
 </div>
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
     <div class="card ~neutral !low limited-height py-2">


### PR DESCRIPTION
Show hourly chart when date range is only 1 day, since that is the only time when the chart is completely useless (only 1 data point). I also set it so the graph is only drawn until the current time (not visible in screenshot since its 11 pm here now, last hour of the day). 

As @haaavk said in his comment, ideally this could be changed by user choice, but I think this is already a good start.

| Daily view (1 week range) | Hourly view (1 day range) |
|------------------|---------------|
|          ![image](https://user-images.githubusercontent.com/25928551/116009613-eff36b80-a61a-11eb-9b06-5a55c639fea6.png)        |       ![image](https://user-images.githubusercontent.com/25928551/116009627-0c8fa380-a61b-11eb-8f11-3c972632bdaa.png)        |




closes #127 