### PR TITLE
Preserve date range across pages

### DIFF
--- a/shynet/dashboard/mixins.py
+++ b/shynet/dashboard/mixins.py
@@ -5,14 +5,16 @@ from django.utils import timezone
 
 
 class DateRangeMixin:
-    def get_start_date(self):
+    def get_start_date(self, use_default=True):
         if self.request.GET.get("startDate") != None:
             found_time = timezone.datetime.strptime(
                 self.request.GET.get("startDate"), "%Y-%m-%d"
             )
             return timezone.make_aware(datetime.combine(found_time, time.min))
-        else:
+        elif use_default == True:
             return timezone.now() - timezone.timedelta(days=30)
+        else:
+            return None
 
     def get_end_date(self):
         if self.request.GET.get("endDate") != None:
@@ -23,8 +25,11 @@ class DateRangeMixin:
         else:
             return timezone.now()
 
+
     def get_context_data(self, **kwargs):
         data = super().get_context_data(**kwargs)
         data["start_date"] = self.get_start_date()
         data["end_date"] = self.get_end_date()
+        start_date = self.get_start_date(False)
+        data["date_query_params"] = f"?startDate={start_date.strftime('%Y-%m-%d')}&endDate={self.get_end_date().strftime('%Y-%m-%d')}" if start_date is not None else ""
         return data

--- a/shynet/dashboard/mixins.py
+++ b/shynet/dashboard/mixins.py
@@ -25,7 +25,6 @@ class DateRangeMixin:
         else:
             return timezone.now()
 
-
     def get_context_data(self, **kwargs):
         data = super().get_context_data(**kwargs)
         data["start_date"] = self.get_start_date()

--- a/shynet/dashboard/mixins.py
+++ b/shynet/dashboard/mixins.py
@@ -5,16 +5,14 @@ from django.utils import timezone
 
 
 class DateRangeMixin:
-    def get_start_date(self, use_default=True):
+    def get_start_date(self):
         if self.request.GET.get("startDate") != None:
             found_time = timezone.datetime.strptime(
                 self.request.GET.get("startDate"), "%Y-%m-%d"
             )
             return timezone.make_aware(datetime.combine(found_time, time.min))
-        elif use_default == True:
-            return timezone.now() - timezone.timedelta(days=30)
         else:
-            return None
+            return timezone.now() - timezone.timedelta(days=30)
 
     def get_end_date(self):
         if self.request.GET.get("endDate") != None:
@@ -29,6 +27,4 @@ class DateRangeMixin:
         data = super().get_context_data(**kwargs)
         data["start_date"] = self.get_start_date()
         data["end_date"] = self.get_end_date()
-        start_date = self.get_start_date(False)
-        data["date_query_params"] = f"?startDate={start_date.strftime('%Y-%m-%d')}&endDate={self.get_end_date().strftime('%Y-%m-%d')}" if start_date is not None else ""
         return data

--- a/shynet/dashboard/templates/base.html
+++ b/shynet/dashboard/templates/base.html
@@ -41,10 +41,8 @@
         <p class="ml-2 mb-1 supra font-medium text-gray-500 pointer-events-none">Services</p>
 
         {% for service in user.owning_services.all %}
-        {% url 'dashboard:service' service.uuid as url %}
-        {% with url_full=date_query_params|default:''|prepend_string:url %}
-        {% include 'dashboard/includes/sidebar_portal.html' with label=service.name|truncatechars:16 url=url_full icon=service.link|iconify %}
-        {% endwith %}
+        {% contextual_url 'dashboard:service' service.uuid as url %}
+        {% include 'dashboard/includes/sidebar_portal.html' with label=service.name|truncatechars:16 url=url icon=service.link|iconify %}
         {% endfor %}
 
         {% endif %}
@@ -62,7 +60,7 @@
         <p class="ml-2 mb-1 supra font-medium text-gray-500 pointer-events-none">Collaborations</p>
 
         {% for service in user.collaborating_services.all %}
-        {% url 'dashboard:service' service.uuid as url %}
+        {% contextual_url 'dashboard:service' service.uuid as url %}
         {% include 'dashboard/includes/sidebar_portal.html' with label=service.name|truncatechars:20 url=url %}
         {% endfor %}
 

--- a/shynet/dashboard/templates/base.html
+++ b/shynet/dashboard/templates/base.html
@@ -42,7 +42,9 @@
 
         {% for service in user.owning_services.all %}
         {% url 'dashboard:service' service.uuid as url %}
-        {% include 'dashboard/includes/sidebar_portal.html' with label=service.name|truncatechars:16 url=url icon=service.link|iconify %}
+        {% with url_full=date_query_params|default:''|prepend_string:url %}
+        {% include 'dashboard/includes/sidebar_portal.html' with label=service.name|truncatechars:16 url=url_full icon=service.link|iconify %}
+        {% endwith %}
         {% endfor %}
 
         {% endif %}

--- a/shynet/dashboard/templates/dashboard/includes/date_range.html
+++ b/shynet/dashboard/templates/dashboard/includes/date_range.html
@@ -2,7 +2,7 @@
     <input type="hidden" name="startDate" value="{{start_date.isoformat}}" id="startDate">
     <input type="hidden" name="endDate" value="{{end_date.isoformat}}" id="endDate">
 </form>
-<input type="input" id="rangePicker" placeholder="Date range" class="input ~neutral bg-neutral-000 cursor-pointer" readonly>
+<input type="input" id="rangePicker" placeholder="Date range" class="input ~neutral bg-neutral-000 cursor-pointer w-auto" readonly>
 <style>
     :root {
         --litepickerMonthButtonHover: var(--color-urge);
@@ -18,7 +18,7 @@
     var picker = new Litepicker({
         element: document.getElementById('rangePicker'),
         singleMode: false,
-        format: 'MMM D, YYYY',
+        format: "MMM DD 'YY",
         maxDate: new Date(),
         startDate: Date.parse(document.getElementById("startDate").getAttribute("value")),
         endDate: Date.parse(document.getElementById("endDate").getAttribute("value")),

--- a/shynet/dashboard/templates/dashboard/includes/service_overview.html
+++ b/shynet/dashboard/templates/dashboard/includes/service_overview.html
@@ -1,6 +1,6 @@
 {% load humanize helpers %}
 
-<a class="card ~neutral !low service mb-6 p-0" href="{% url 'dashboard:service' object.uuid %}">
+<a class="card ~neutral !low service mb-6 p-0" href="{% url 'dashboard:service' object.uuid %}{{date_query_params}}">
     {% with stats=object.stats %}
     <div class="p-4 md:flex justify-between">
         <div class="flex items-center mb-4 md:mb-0">

--- a/shynet/dashboard/templates/dashboard/includes/service_overview.html
+++ b/shynet/dashboard/templates/dashboard/includes/service_overview.html
@@ -1,6 +1,6 @@
 {% load humanize helpers %}
 
-<a class="card ~neutral !low service mb-6 p-0" href="{% url 'dashboard:service' object.uuid %}{{date_query_params}}">
+<a class="card ~neutral !low service mb-6 p-0" href="{% contextual_url 'dashboard:service' object.uuid %}">
     {% with stats=object.stats %}
     <div class="p-4 md:flex justify-between">
         <div class="flex items-center mb-4 md:mb-0">

--- a/shynet/dashboard/templates/dashboard/includes/session_list.html
+++ b/shynet/dashboard/templates/dashboard/includes/session_list.html
@@ -12,7 +12,7 @@
         {% for session in object_list %}
         <tr>
             <td>
-                <a href="{% url 'dashboard:service_session' object.pk session.pk %}"
+                <a href="{% url 'dashboard:service_session' object.pk session.pk %}{{date_query_params}}"
                     class="font-medium text-urge-700">
                     {{session.start_time|date:"M j Y, g:i a"|capfirst}}
                     {% if session.is_currently_active %}

--- a/shynet/dashboard/templates/dashboard/includes/session_list.html
+++ b/shynet/dashboard/templates/dashboard/includes/session_list.html
@@ -12,7 +12,7 @@
         {% for session in object_list %}
         <tr>
             <td>
-                <a href="{% url 'dashboard:service_session' object.pk session.pk %}{{date_query_params}}"
+                <a href="{% contextual_url 'dashboard:service_session' object.pk session.pk %}"
                     class="font-medium text-urge-700">
                     {{session.start_time|date:"M j Y, g:i a"|capfirst}}
                     {% if session.is_currently_active %}

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -6,7 +6,7 @@
 <div class="mr-2">{% include 'dashboard/includes/date_range.html' %}</div>
 {% has_perm 'core.change_service' user object as can_update %}
 {% if can_update %}
-<a href="{% url 'dashboard:service_update' service.uuid %}" class="button field bg-neutral-000 w-auto">Manage &rarr;</a>
+<a href="{% contextual_url 'dashboard:service_update' service.uuid %}" class="button field bg-neutral-000 w-auto">Manage &rarr;</a>
 {% endif %}
 {% endblock %}
 
@@ -235,7 +235,7 @@
 <div class="card ~neutral !low limited-height py-2">
     {% include 'dashboard/includes/session_list.html' %}
     <hr class="sep h-8">
-    <a href="{% url 'dashboard:service_session_list' service.uuid %}{{date_query_params}}" class="button ~neutral w-auto mb-2">View more
+    <a href="{% contextual_url 'dashboard:service_session_list' service.uuid %}" class="button ~neutral w-auto mb-2">View more
         sessions
         &rarr;</a>
 </div>

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -235,7 +235,7 @@
 <div class="card ~neutral !low limited-height py-2">
     {% include 'dashboard/includes/session_list.html' %}
     <hr class="sep h-8">
-    <a href="{% url 'dashboard:service_session_list' service.uuid %}" class="button ~neutral w-auto mb-2">View more
+    <a href="{% url 'dashboard:service_session_list' service.uuid %}{{date_query_params}}" class="button ~neutral w-auto mb-2">View more
         sessions
         &rarr;</a>
 </div>

--- a/shynet/dashboard/templates/dashboard/pages/service_session.html
+++ b/shynet/dashboard/templates/dashboard/pages/service_session.html
@@ -5,7 +5,7 @@
 {% block head_title %}{{object.name}} Session{% endblock %}
 
 {% block service_actions %}
-<a href="{% url 'dashboard:service' object.uuid %}" class="button field bg-neutral-000 w-auto">Analytics &rarr;</a>
+<a href="{% contextual_url 'dashboard:service' object.uuid %}" class="button field bg-neutral-000 w-auto">Analytics &rarr;</a>
 {% endblock %}
 
 {% block service_content %}

--- a/shynet/dashboard/templates/dashboard/pages/service_session_list.html
+++ b/shynet/dashboard/templates/dashboard/pages/service_session_list.html
@@ -6,7 +6,7 @@
 
 {% block service_actions %}
 <div class="mr-2">{% include 'dashboard/includes/date_range.html' %}</div>
-<a href="{% url 'dashboard:service' object.uuid %}" class="button field ~neutral bg-neutral-000 w-auto">Analytics &rarr;</a>
+<a href="{% url 'dashboard:service' object.uuid %}{{date_query_params}}" class="button field ~neutral bg-neutral-000 w-auto">Analytics &rarr;</a>
 {% endblock %}
 
 {% block service_content %}

--- a/shynet/dashboard/templates/dashboard/pages/service_session_list.html
+++ b/shynet/dashboard/templates/dashboard/pages/service_session_list.html
@@ -6,7 +6,7 @@
 
 {% block service_actions %}
 <div class="mr-2">{% include 'dashboard/includes/date_range.html' %}</div>
-<a href="{% url 'dashboard:service' object.uuid %}{{date_query_params}}" class="button field ~neutral bg-neutral-000 w-auto">Analytics &rarr;</a>
+<a href="{% contextual_url 'dashboard:service' object.uuid %}" class="button field ~neutral bg-neutral-000 w-auto">Analytics &rarr;</a>
 {% endblock %}
 
 {% block service_content %}

--- a/shynet/dashboard/templates/dashboard/service_base.html
+++ b/shynet/dashboard/templates/dashboard/service_base.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="md:flex justify-between items-center" id="heading">
-    <a class="flex items-center mb-4 md:mb-0" href="{% url 'dashboard:service' object.uuid %}{{date_query_params}}">
+    <a class="flex items-center mb-4 md:mb-0" href="{% contextual_url 'dashboard:service' object.uuid %}">
         <h3 class="heading leading-none mr-4">
             {{object.link|iconify}}
             {{object.name}}

--- a/shynet/dashboard/templates/dashboard/service_base.html
+++ b/shynet/dashboard/templates/dashboard/service_base.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="md:flex justify-between items-center" id="heading">
-    <a class="flex items-center mb-4 md:mb-0" href="{% url 'dashboard:service' object.uuid %}">
+    <a class="flex items-center mb-4 md:mb-0" href="{% url 'dashboard:service' object.uuid %}{{date_query_params}}">
         <h3 class="heading leading-none mr-4">
             {{object.link|iconify}}
             {{object.name}}

--- a/shynet/dashboard/templatetags/helpers.py
+++ b/shynet/dashboard/templatetags/helpers.py
@@ -186,5 +186,5 @@ def urldisplay(url):
         return url
 
 @register.filter
-def add_string(arg1, arg2):
-    return f"{str(arg1)}{str(arg2)}"
+def prepend_string(arg1, arg2):
+    return f"{str(arg2)}{str(arg1)}"

--- a/shynet/dashboard/templatetags/helpers.py
+++ b/shynet/dashboard/templatetags/helpers.py
@@ -184,3 +184,7 @@ def urldisplay(url):
         )
     else:
         return url
+
+@register.filter
+def add_string(arg1, arg2):
+    return f"{str(arg1)}{str(arg2)}"


### PR DESCRIPTION
When navigating between `service overview`, `service` and `service session list` pages, the date range will now be preserved.

Currently though, if you go from one of the 3 above pages to for example the `create service` page, but then cancel, you will return to the `service overview` page and the date range will be reset. I can fix this by also adding the query parameters to pages that do not actually use a date range, just for the sake of passing it to other pages that possibly do use a date range. 

Let me know if I should add that.

closes #136 