### PR TITLE
Datepicker mobile overflow

### DIFF
--- a/shynet/dashboard/templates/dashboard/includes/date_range.html
+++ b/shynet/dashboard/templates/dashboard/includes/date_range.html
@@ -2,7 +2,7 @@
     <input type="hidden" name="startDate" value="{{start_date.isoformat}}" id="startDate">
     <input type="hidden" name="endDate" value="{{end_date.isoformat}}" id="endDate">
 </form>
-<input type="input" id="rangePicker" placeholder="Date range" class="input ~neutral bg-neutral-000 cursor-pointer w-auto" readonly>
+<input type="input" id="rangePicker" placeholder="Date range" class="input ~neutral bg-neutral-000 cursor-pointer" readonly>
 <style>
     :root {
         --litepicker-button-prev-month-color-hover: var(--color-urge);

--- a/shynet/dashboard/templates/dashboard/includes/date_range.html
+++ b/shynet/dashboard/templates/dashboard/includes/date_range.html
@@ -2,7 +2,7 @@
     <input type="hidden" name="startDate" value="{{start_date.isoformat}}" id="startDate">
     <input type="hidden" name="endDate" value="{{end_date.isoformat}}" id="endDate">
 </form>
-<input type="input" id="rangePicker" placeholder="Date range" class="input ~neutral bg-neutral-000 cursor-pointer" readonly>
+<input type="input" id="rangePicker" placeholder="Date range" class="input ~neutral bg-neutral-000 cursor-pointer" style="max-width: 200px;" readonly>
 <style>
     :root {
         --litepicker-button-prev-month-color-hover: var(--color-urge);


### PR DESCRIPTION
Made it so the date picker auto shrinks on smaller displays, this is something I messed up in #120.

| Before | After|
|-------|---------|
|![analytics casperverswijvelt be_dashboard_service_ba385d2a-5c80-4b31-931e-3da309fac8d0_(iPhone 5_SE)](https://user-images.githubusercontent.com/25928551/119260164-dd486400-bbd1-11eb-8388-bf79c2a61d17.png)  |  ![192 168 69 11_4848_dashboard_service_db3c54c6-e9e5-44f2-bfd1-8ea8296c327d__startDate=2020-1-31 endDate=2020-1-31(iPhone 5_SE)](https://user-images.githubusercontent.com/25928551/119260165-dde0fa80-bbd1-11eb-9411-7a2383655617.png) |

Also gave the date picker element a smaller fixed width since `width: auto` does not work on the value of input elements, and there was always some white space.

| Before | After|
|-------|---------|
|![analytics casperverswijvelt be_dashboard_service_ba385d2a-5c80-4b31-931e-3da309fac8d0_(iPad)](https://user-images.githubusercontent.com/25928551/119260218-1f71a580-bbd2-11eb-8bb9-acf516485d83.png) | ![192 168 69 11_4848_dashboard_service_db3c54c6-e9e5-44f2-bfd1-8ea8296c327d__startDate=2020-1-31 endDate=2020-1-31(iPad)](https://user-images.githubusercontent.com/25928551/119260224-23052c80-bbd2-11eb-9f0d-c60ca8c1bc3f.png)|