### PR TITLE
Add ability to toggle between map chart and country/session table

### DIFF
--- a/shynet/dashboard/static/dashboard/css/global.css
+++ b/shynet/dashboard/static/dashboard/css/global.css
@@ -11,11 +11,6 @@
     max-height: 400px;
 }
 
-.force-limited-height {
-    max-height: 400px;
-    overflow: hidden;
-}
-
 .rf {
     text-align: right !important;
 }
@@ -26,6 +21,18 @@
 
 .max-w-0 {
     max-width: 0;
+}
+
+.geo-table {
+    display: none;
+}
+
+.geo-card--use-table-view .geo-map {
+    display: none;
+}
+
+.geo-card--use-table-view .geo-table {
+    display: inline-block
 }
 
 :root {

--- a/shynet/dashboard/static/dashboard/css/global.css
+++ b/shynet/dashboard/static/dashboard/css/global.css
@@ -23,6 +23,10 @@
     max-width: 0;
 }
 
+.min-w-48 {
+    min-width: 48px
+}
+
 .geo-table {
     display: none;
 }

--- a/shynet/dashboard/static/dashboard/css/global.css
+++ b/shynet/dashboard/static/dashboard/css/global.css
@@ -24,7 +24,7 @@
 }
 
 .min-w-48 {
-    min-width: 48px
+    min-width: 48px;
 }
 
 .geo-table {
@@ -36,7 +36,7 @@
 }
 
 .geo-card--use-table-view .geo-table {
-    display: inline-block
+    display: inline-block;
 }
 
 :root {

--- a/shynet/dashboard/templates/dashboard/includes/map_chart.html
+++ b/shynet/dashboard/templates/dashboard/includes/map_chart.html
@@ -33,7 +33,7 @@
     }
 
     // Create datamap
-    const map = new Datamap({
+    var geoMap = new Datamap({
         element: document.getElementById('map-chart'),
         projection: 'mercator',
         responsive: true,
@@ -52,8 +52,15 @@
         data: countryMapData,
         aspectRatio: 0.68
     });
-    map.updateChoropleth(countryMapColors);
+    geoMap.updateChoropleth(countryMapColors);
     
-    // Handle resize. TODO: debounce?
-    window.onresize = () => map.resize();
+    let debounceTimeout
+    const debounce = (func, debounce) => {
+        return function(event){
+            if(debounceTimeout) clearTimeout(debounceTimeout);
+            debounceTimeout = setTimeout(func,debounce,event);
+        };
+    }
+
+    window.addEventListener("resize",debounce(() => geoMap.resize(), 100))
 </script>

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -135,9 +135,9 @@
     <div class="geo-map card ~neutral !low py-2 overflow-y-hidden">
         <p class="text-sm font-semibold p-2 border-b mb-2" style="color: var(--color-title)">
             Sessions by Geography &nbsp
-            <span onclick="document.getElementById('card-grid').classList.add('geo-card--use-table-view')" class="text-xs select-none p-0 button ~urge !low">
-                (switch to table view)
-            </span>
+            <button onclick="document.getElementById('card-grid').classList.add('geo-card--use-table-view')" class="text-xs select-none p-0 button ~urge !low">
+                (view table)
+            </button>
         </p>
         {% include 'dashboard/includes/map_chart.html' with countries=stats.countries %}
     </div>
@@ -147,9 +147,9 @@
                 <tr>
                     <th>
                         Country &nbsp
-                        <span onclick="document.getElementById('card-grid').classList.remove('geo-card--use-table-view'); geoMap.resize()" class="text-xs select-none p-0 button ~urge !low">
-                            (switch to map view)
-                        </span>
+                        <button onclick="document.getElementById('card-grid').classList.remove('geo-card--use-table-view'); geoMap.resize()" class="text-xs select-none p-0 button ~urge !low">
+                            (view map)
+                        </button>
                     </th>
                     <th class="rf">Sessions</th>
                 </tr>

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -133,28 +133,37 @@
         </table>
     </div>
     <div class="geo-map card ~neutral !low py-2 overflow-y-hidden">
-        <p class="text-sm font-semibold p-2 border-b mb-2" style="color: var(--color-title)">Sessions by Geography <span onclick="document.getElementById('card-grid').classList.add('geo-card--use-table-view')" class="float-right select-none p-0 button ~urge !low">table</span></p>
+        <p class="text-sm font-semibold p-2 border-b mb-2" style="color: var(--color-title)">
+            Sessions by Geography &nbsp
+            <span onclick="document.getElementById('card-grid').classList.add('geo-card--use-table-view')" class="text-xs select-none p-0 button ~urge !low">
+                (switch to table view)
+            </span>
+        </p>
         {% include 'dashboard/includes/map_chart.html' with countries=stats.countries %}
     </div>
     <div class="geo-table card ~neutral !low limited-height py-2">
         <table class="table">
             <thead class="text-sm">
                 <tr>
-                    <th>Country</th>
-                    <th colspan="2" class="rf">Sessions</th>
-                    <th class="rf"><span onclick="document.getElementById('card-grid').classList.remove('geo-card--use-table-view'); geoMap.resize()" class="float-right select-none p-0 button ~urge !low">map</span></th>
+                    <th>
+                        Country &nbsp
+                        <span onclick="document.getElementById('card-grid').classList.remove('geo-card--use-table-view'); geoMap.resize()" class="text-xs select-none p-0 button ~urge !low">
+                            (switch to map view)
+                        </span>
+                    </th>
+                    <th class="rf">Sessions</th>
                 </tr>
             </thead>
             <tbody>
                 {% for country in stats.countries %}
                 <tr>
-                    <td colspan="2" class="truncate w-full max-w-0 relative" title="{{country.country|country_name}}">
+                    <td class="truncate w-full max-w-0 relative" title="{{country.country|country_name}}">
                         {% include 'dashboard/includes/bar.html' with count=country.count max=stats.countries.0.count total=stats.session_count %}
                         <div class="relative flex items-center">
                             <span class="flex-none {{country.country|flag_class}}"></span> <span class="truncate">{{country.country|country_name}}</span>
                         </div>
                     </td>
-                    <td colspan="2">
+                    <td>
                         <div class="flex justify-end items-center">
                             {{country.count|intcomma}}
                             <span class="text-xs rf" style="min-width: 48px">

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -141,17 +141,27 @@
             <thead class="text-sm">
                 <tr>
                     <th>Country</th>
-                    <th class="rf">Sessions</th>
+                    <th colspan="2" class="rf">Sessions</th>
                     <th class="rf"><span onclick="document.getElementById('card-grid').classList.remove('geo-card--use-table-view'); geoMap.resize()" class="float-right select-none p-0 button ~urge !low">map</span></th>
                 </tr>
             </thead>
             <tbody>
                 {% for country in stats.countries %}
                 <tr>
-                    <td colspan="2" class="truncate w-full max-w-0" title="{{country.country|country_name}}">
-                        <span class="{{country.country|flag_class}}"></span> {{country.country|country_name}}
+                    <td colspan="2" class="truncate w-full max-w-0 relative" title="{{country.country|country_name}}">
+                        {% include 'dashboard/includes/bar.html' with count=country.count max=stats.countries.0.count total=stats.session_count %}
+                        <div class="relative flex items-center">
+                            <span class="flex-none {{country.country|flag_class}}"></span> <span class="truncate">{{country.country|country_name}}</span>
+                        </div>
                     </td>
-                    <td class="rf">{{country.count|intcomma}}</td>
+                    <td colspan="2">
+                        <div class="flex justify-end items-center">
+                            {{country.count|intcomma}}
+                            <span class="text-xs rf" style="min-width: 48px">
+                                ({{country.count|percent:stats.session_count}})
+                            </span>
+                        </div>
+                    </td>
                 </tr>
                 {% empty %}
                 <tr>

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -97,7 +97,7 @@
     {% include 'dashboard/includes/time_chart.html' with data=stats.chart_data tooltip_format=stats.chart_tooltip_format granularity=stats.chart_granularity click_zoom=True %}
 </div>
 {% endif %}
-<div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+<div id="card-grid" class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
     <div class="card ~neutral !low limited-height py-2">
         <table class="table">
             <thead class="text-sm">
@@ -132,9 +132,34 @@
             </tbody>
         </table>
     </div>
-    <div class="card ~neutral !low force-limited-height py-2 overflow-y-hidden">
-        <p class="text-sm font-semibold mx-2 p-2 border-b mb-2">Sessions by Geography</p>
+    <div class="geo-map card ~neutral !low py-2 overflow-y-hidden">
+        <p class="text-sm font-semibold p-2 border-b mb-2" style="color: var(--color-title)">Sessions by Geography <span onclick="document.getElementById('card-grid').classList.add('geo-card--use-table-view')" class="float-right select-none p-0 button ~urge !low">table</span></p>
         {% include 'dashboard/includes/map_chart.html' with countries=stats.countries %}
+    </div>
+    <div class="geo-table card ~neutral !low limited-height py-2">
+        <table class="table">
+            <thead class="text-sm">
+                <tr>
+                    <th>Country</th>
+                    <th class="rf">Sessions</th>
+                    <th class="rf"><span onclick="document.getElementById('card-grid').classList.remove('geo-card--use-table-view'); geoMap.resize()" class="float-right select-none p-0 button ~urge !low">map</span></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for country in stats.countries %}
+                <tr>
+                    <td colspan="2" class="truncate w-full max-w-0" title="{{country.country|country_name}}">
+                        <span class="{{country.country|flag_class}}"></span> {{country.country|country_name}}
+                    </td>
+                    <td class="rf">{{country.count|intcomma}}</td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td><span class="text-gray-600">No data yet...</span></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
     <div class="card ~neutral !low limited-height py-2">
         <table class="table">

--- a/shynet/dashboard/templates/dashboard/pages/service.html
+++ b/shynet/dashboard/templates/dashboard/pages/service.html
@@ -118,7 +118,7 @@
                     <td>
                         <div class="flex justify-end items-center">
                             {{location.count|intcomma}}
-                            <span class="text-xs rf" style="min-width: 48px">
+                            <span class="text-xs rf min-w-48">
                                 ({{location.count|percent:stats.hit_count}})
                             </span>
                         </div>
@@ -166,7 +166,7 @@
                     <td>
                         <div class="flex justify-end items-center">
                             {{country.count|intcomma}}
-                            <span class="text-xs rf" style="min-width: 48px">
+                            <span class="text-xs rf min-w-48">
                                 ({{country.count|percent:stats.session_count}})
                             </span>
                         </div>
@@ -200,7 +200,7 @@
                     <td>
                         <div class="flex justify-end items-center">
                             {{referrer.count|intcomma}}
-                            <span class="text-xs rf" style="min-width: 48px">
+                            <span class="text-xs rf min-w-48">
                                 ({{referrer.count|percent:stats.session_count}})
                             </span>
                         </div>
@@ -234,7 +234,7 @@
                     <td>
                         <div class="flex justify-end items-center">
                             {{os.count|intcomma}}
-                            <span class="text-xs rf" style="min-width: 48px">
+                            <span class="text-xs rf min-w-48">
                                 ({{os.count|percent:stats.session_count}})
                             </span>
                         </div>
@@ -269,7 +269,7 @@
                     <td>
                         <div class="flex justify-end items-center">
                             {{browser.count|intcomma}}
-                            <span class="text-xs rf" style="min-width: 48px">
+                            <span class="text-xs rf min-w-48">
                                 ({{browser.count|percent:stats.session_count}})
                             </span>
                         </div>
@@ -303,7 +303,7 @@
                     <td>
                         <div class="flex justify-end items-center">
                             {{device_type.count|intcomma}}
-                            <span class="text-xs rf" style="min-width: 48px">
+                            <span class="text-xs rf min-w-48">
                                 ({{device_type.count|percent:stats.session_count}})
                             </span>
                         </div>


### PR DESCRIPTION
As talked about in #142, this pull request adds a toggle button in the header of the card to switch between map/table view.

| Table view | Map view |
|------------|----------|
| ![image](https://user-images.githubusercontent.com/25928551/122286489-33b67300-cef0-11eb-93e1-46cff198eb5b.png) | ![image](https://user-images.githubusercontent.com/25928551/122286547-4466e900-cef0-11eb-853e-8f278ed4e321.png) |

On smaller screens like the iPhone 5 the text wraps but I think it's still fine.

| Table view | Map view |
|------------|----------|
|  ![image](https://user-images.githubusercontent.com/25928551/122286907-a9bada00-cef0-11eb-908b-4eb8ad76ff21.png) | ![image](https://user-images.githubusercontent.com/25928551/122286736-75dfb480-cef0-11eb-946d-7bd285d598c6.png) |

Right now the default view is always the map view, but maybe this should be dependent on the screen size? I think viewing on mobile maybe we should start out with the table view as the map view is a bit awkward on mobile?