### PR TITLE
Set permissions on privkey

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -118,6 +118,7 @@ If you are going to be running Shynet through a reverse proxy, please see [Confi
 
 4. We are going to move the SSL certificates to the Shynet repo with with command below. Replace `<domain>` with the domain name you used in step 3.
    * `cp /etc/letsencrypt/live/<domain>/{cert,privkey}.pem ~/shynet/shynet/`
+   * `chmod 644 ~/shynet/shynet/privkey.pem`
 
 5. With that, we are going to replace the `webserver.sh` with `ssl.webserver.sh` to enable the use of SSL certificates. The original `webserver.sh` will be backed up to `backup.webserver.sh`
    * `mv ~/shynet/shynet/webserver.sh ~/shynet/shynet/backup.webserver.sh`


### PR DESCRIPTION
Using [Installation with SSL](https://github.com/milesmcc/shynet/blob/master/GUIDE.md#installation-with-ssl) I got the error below. I encountered this on both Debian 10 and Centos 8.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/gunicorn/workers/sync.py", line 129, in handle
    client = ssl.wrap_socket(client, server_side=True,
  File "/usr/local/lib/python3.9/ssl.py", line 1402, in wrap_socket
    context.load_cert_chain(certfile, keyfile)
PermissionError: [Errno 13] Permission denied
```

The proposed change fixes the issue, but I don't know if it's the most correct way.