### PR TITLE
Add multi stage build for docker for dev env, and placehoder for cerleryworker in docker compose

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -54,19 +54,29 @@ Before continuing, please be sure to have the latest version of Docker installed
 
 > Make sure you have `docker-compose` installed. If not, [install it](https://docs.docker.com/compose/install/) 
 
+**NOTE**
+There are 3 docker compose files, following [docker-compose extends](https://docs.docker.com/compose/extends/) practices. `docker-compose.yaml` contains all the shared configurations. `docker-compose.override.yaml` contains all the development configurations and setup a development environment with docker compose (mount the code in the container and auto-reloading). `docker-compose.prod.yaml` has the necessary additions for production setup using nginx.
+
+Note that when you do `docker-compose up`, docker-compose will automatically pickup the base + override file. If you want to deploy to production, make sure you pass the appropriate flags.
+
+**For development you do not need to specify the `-f` flags. For production make sure you use both `-f docker-compose.yml -f docker-compose.prod.yml`
+
 1. Clone the repository.
 
 2. Using [TEMPLATE.env](/TEMPLATE.env) as a template, confiure the environment for your Shynet instance and place the modified config in a file called `.env` in the root of the repository. Do _not_ change the port number at the end; you can set the public facing port in the next step. 
 
-3. On line 2 of the `nginx.conf` file located in the root of the repository, replace `example.com` with your hostname. Then, in the `docker-compose.yml` file, set the port number by replacing `8080` in line 38 ( `- 8080:80` ) with whatever local port you want to bind it to. For example, set the port number to `- 80:80` if you want your site will be available via HTTP (port 80) at `http://<your hostname>`.
+3. On line 2 of the `nginx.conf` file located in the root of the repository, replace `example.com` with your hostname. Then, in the `docker-compose.prod.yml` file, set the port number by replacing `8080` in line 38 ( `- 8080:80` ) with whatever local port you want to bind it to. For example, set the port number to `- 80:80` if you want your site will be available via HTTP (port 80) at `http://<your hostname>`.
 
-4. Launch the Shynet server for the first time by running `docker-compose up -d`. If you get an error like "permission denied" or "Couldn't connect to Docker daemon", either prefix the command with `sudo` or add your user to the `docker` group.
+4. Launch the Shynet server for the first time by running `docker-compose  -f docker-compose.yml -f docker-compose.prod.yml up -d`. If you get an error like "permission denied" or "Couldn't connect to Docker daemon", either prefix the command with `sudo` or add your user to the `docker` group.
 
-5. Create an admin user by running `docker exec -it shynet_main ./manage.py registeradmin <your email>`. A temporary password will be printed to the console.
+5. Create an admin user by running `docker exec -it -f docker-compose.yml -f docker-compose.prod.yml shynet_main ./manage.py registeradmin <your email>`. A temporary password will be printed to the console.
 
-6. Set the whitelabel of your Shynet instance by running `docker exec -it shynet_main ./manage.py whitelabel <whitelabel>`. While this setting doesn't affect any core operations of Shynet, it lets you rename Shynet to whatever you want. (Example whitelabels: "My Shynet Instance" or "Acme Analytics".)
+6. Set the whitelabel of your Shynet instance by running `docker exec -it -f docker-compose.yml -f docker-compose.prod.yml shynet_main ./manage.py whitelabel <whitelabel>`. While this setting doesn't affect any core operations of Shynet, it lets you rename Shynet to whatever you want. (Example whitelabels: "My Shynet Instance" or "Acme Analytics".)
 
 Your site should now be accessible at `http://hostname:port`. Now you can follow steps 9-10 of the [Basic Installation](#basic-installation) guide above to get Shynet integrated on your sites.
+
+**OPTIONAL**
+You can also enable a celery worker as a separate deployment by un-commenting the lines in `docker-compose.prod.yml` 
 
 ## Heroku
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  shynet:
+    volumes:
+      - ./shynet:/usr/src/shynet
+    build: 
+      target: development
+    command: ./dev_entrypoint.sh
+    ports:
+      - 8080:8080

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  shynet:
+    build:
+      context: .
+      target: production
+    expose:
+      - 8080
+  #   environment:
+  #     - CELERY_BROKER_URL=redis://redis
+  #     - CELERY_TASK_ALWAYS_EAGER=False
+  webserver:
+    container_name: shynet_webserver
+    image: nginx
+    restart: always
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf    
+    ports:
+      - 8080:80
+    depends_on:
+      - shynet
+    networks:
+      - internal
+  # celery_worker:
+  #   container_name: shynet_worker
+  #   image: milesmcc/shynet:latest
+  #   command: "./celeryworker.sh"
+  #   depends_on:
+  #     - redis
+  #     - shynet
+  #   networks:
+  #     - internal
+  #   environment:
+  #     - CELERY_BROKER_URL=redis://redis
+  #     - NUM_WORKERS=1
+  # redis:
+  #   image: "redis:alpine"
+  #   networks:
+  #     - internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,11 @@ version: '3'
 services:
   shynet:
     container_name: shynet_main
+    build:
+      context: .
+      target: production
     image: milesmcc/shynet:latest
     restart: unless-stopped
-    expose:
-      - 8080
     env_file:
       # Create a file called '.env' if it doesn't already exist.
       # You can use `TEMPLATE.env` as a guide.
@@ -26,18 +27,6 @@ services:
       - "POSTGRES_DB=${DB_NAME}"
     volumes:
       - shynet_db:/var/lib/postgresql/data
-    networks:
-      - internal
-  webserver:
-    container_name: shynet_webserver
-    image: nginx
-    restart: always
-    volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf    
-    ports:
-      - 8080:80
-    depends_on:
-      - shynet
     networks:
       - internal
 volumes:

--- a/shynet/dev_entrypoint.sh
+++ b/shynet/dev_entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "STARTING DEV SERVER"
+./manage.py migrate && echo "Migrations complete!"
+./manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
# Overhauls Docker setup

- Makes use of multi stage builds to get a development environment with docker
- Removes Nginx from base and dev builds, and only adds them to production docker-compose using compose extends - https://docs.docker.com/compose/extends/
- Updates documentation
- Adds celery worker to and redis to the docker-compose prod setup, but keeps them commented and ready for use