### PR TITLE
Remove empty js script from template

### DIFF
--- a/shynet/dashboard/templates/base.html
+++ b/shynet/dashboard/templates/base.html
@@ -15,7 +15,6 @@
   <script src="{% static 'd3/d3.min.js' %}"></script>
   <script src="{% static 'topojson/build/topojson.min.js' %}"></script>
   <script src="{% static 'datamaps/dist/datamaps.world.min.js' %}"></script>
-  <script src="{% static 'dashboard/js/base.js' %}"></script>
   <link rel="stylesheet" href="{% static 'dashboard/css/global.css' %}">
   <link rel="stylesheet" href="{% static 'flag-icon-css/css/flag-icon.min.css' %}">
   <link rel="stylesheet" href="{% static 'litepicker/dist/css/litepicker.css' %}">


### PR DESCRIPTION
Serving empty file raise ValueError in gunicorn.

[2022-01-02 12:11:26 +0100] [8] [ERROR] Error handling request                                                   
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/gunicorn/workers/sync.py", line 182, in handle_request
    resp.write_file(respiter)
  File "/usr/local/lib/python3.10/site-packages/gunicorn/http/wsgi.py", line 385, in write_file
    if not self.sendfile(respiter):
  File "/usr/local/lib/python3.10/site-packages/gunicorn/http/wsgi.py", line 375, in sendfile
    self.sock.sendfile(respiter.filelike, count=nbytes)
  File "/usr/local/lib/python3.10/socket.py", line 484, in sendfile
    return self._sendfile_use_sendfile(file, offset, count)                                                      
  File "/usr/local/lib/python3.10/socket.py", line 348, in _sendfile_use_sendfile                                
    self._check_sendfile_params(file, offset, count)                                                             
  File "/usr/local/lib/python3.10/socket.py", line 462, in _check_sendfile_params                                
    raise ValueError(                                                                                            
ValueError: count must be a positive integer (got 0)