### PR TITLE
Fix SQLite support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,9 @@ RUN apk --purge del .build-deps && \
 	rm -rf /var/lib/apt/lists/* && \
 	rm /var/cache/apk/* && \
 	addgroup --system -g $GF_GID appgroup && \
-	adduser appuser --system --uid $GF_UID -G appgroup
+	adduser appuser --system --uid $GF_UID -G appgroup && \
+	mkdir -p /var/local/shynet/db/ && \
+	chown -R appuser:appgroup /var/local/shynet
 
 # Install Shynet
 COPY shynet .

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -32,7 +32,11 @@ Before continuing, please be sure to have the latest version of Docker installed
 
 1. Pull the latest version of Shynet using `docker pull milesmcc/shynet:latest`. If you don't have Docker installed, [install it](https://docs.docker.com/get-docker/).
 
-2. Have a PostgreSQL server ready to go. This can be on the same machine as the deployment, or elsewhere. You'll just need a username, password, host, and port. (For info on how to setup a PostgreSQL server on Ubuntu, follow [this guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-18-04)).
+2. For database you can use either PostgreSQL or SQLite:
+
+    2.1 To use PostgreSQL you need a server ready to go. This can be on the same machine as the deployment, or elsewhere. You'll need a username, password, host, and port, set in the appropriate `DB_` environment variables (see next). (For info on how to setup a PostgreSQL server on Ubuntu, follow [this guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-on-ubuntu-18-04)).
+
+    2.2 SQLite doesn't need a server, just a file. Set `SQLITE=True` in the environment file and create a Docker volume to hold the persistent DB with `docker volume create shynet_db`. Then whenever you run the container include `-v shynet_db:/var/local/shynet/db:rw` to mount the volume into the container. See the [Docker documentation on volumes](https://docs.docker.com/storage/volumes/).
 
 3. Configure an environment file for Shynet, using [this file](/TEMPLATE.env) as a template. (This file is typically named `.env`.) Make sure you set the database settings, or Shynet won't be able to run. Also consider setting `ALLOWED_HOSTS` inside the environment file to your deployment's domain for better security.
 

--- a/TEMPLATE.env
+++ b/TEMPLATE.env
@@ -9,6 +9,10 @@ DB_PASSWORD=shynet_db_user_password
 DB_HOST=db
 DB_PORT=5432
 
+# Database settings (SQLite) - comment PostgreSQL settings
+# SQLITE=True
+# DB_NAME=/var/local/shynet/db
+
 # Email settings (optional)
 EMAIL_HOST_USER=example
 EMAIL_HOST_PASSWORD=example_password

--- a/shynet/shynet/settings.py
+++ b/shynet/shynet/settings.py
@@ -100,13 +100,13 @@ WSGI_APPLICATION = "shynet.wsgi.application"
 
 
 # Database
-# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
+# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 if os.getenv("SQLITE", "False") == "True":
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
-            "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+            "NAME": os.environ.get("DB_NAME", "/var/local/shynet/db/db.sqlite3"),
         }
     }
 else:


### PR DESCRIPTION
SQLite DB was not writable because it was always located in `/usr/src/shynet/`, which is owned by root and not writable by `appuser`. SQLite needs the parent directory containing the DB file to be writable by the running user.

The applied fix is to place the DB file in `/var/local/shynet/db` and to create that directory in the Docker image with the right permissions.

SQLite setup is now documented in *README* as an alternative to Postgres.

Fixes #208.