### PR TITLE
Provide full path for example sqlite path

### DIFF
--- a/TEMPLATE.env
+++ b/TEMPLATE.env
@@ -11,7 +11,7 @@ DB_PORT=5432
 
 # Database settings (SQLite) - comment PostgreSQL settings
 # SQLITE=True
-# DB_NAME=/var/local/shynet/db
+# DB_NAME=/var/local/shynet/db/db.sqlite3
 
 # Email settings (optional)
 EMAIL_HOST_USER=example


### PR DESCRIPTION
The Dockerfile currently creates a directory at /var/local/shynet/db/.
The `DB_NAME` in the example file caused migrations to fail as a result.