### PR TITLE
fix registeradmin's get_random_string missing argument

### DIFF
--- a/shynet/core/management/commands/registeradmin.py
+++ b/shynet/core/management/commands/registeradmin.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         email = options.get("email")
-        password = get_random_string()
+        password = get_random_string(10)
         User.objects.create_superuser(str(uuid.uuid4()), email=email, password=password)
         self.stdout.write(self.style.SUCCESS("Successfully created a Shynet superuser"))
         self.stdout.write(f"Email address: {email}")


### PR DESCRIPTION
Hi, thank you for the great work on shynet this is a quick fix for this issue https://github.com/milesmcc/shynet/issues/234.
Maybe we should increase the length of the password and/or ask for it in the config file, i'll try to work on a sweeter solution in the futur.