### PR TITLE
fix: PyYAML dependency install (check #183) (temporary)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
 
     steps:
       - uses: actions/checkout@v2
@@ -27,10 +27,11 @@ jobs:
       - name: Run image
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.2.2
+      - name: Preinstall dependencies (temporary)
+        run: poetry run pip install "Cython<3.0" "pyyaml==5.4.1" --no-build-isolation
       - name: Install dependencies 
         run: poetry install
-        
       - name: Django Testing project
         run: |
           cp TEMPLATE.env .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache postgresql-libs && \
 
 # Install Python dependencies
 RUN poetry config virtualenvs.create false && \
+    poetry run pip install "Cython<3.0" "pyyaml==5.4.1" --no-build-isolation && \
     poetry install --no-dev --no-interaction --no-ansi
 
 # Cleanup dependencies & setup user group


### PR DESCRIPTION
Fix PyYAML dependency installation. Due to Cython 3.0 (released today)?

```
  • Installing pyyaml (5.4.1): Failed

  CalledProcessError

  Command '['/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10/bin/python', '-m', 'pip', 'install', '--use-pep517', '--disable-pip-version-check', '--prefix', '/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10', '--no-deps', '/root/.cache/pypoetry/artifacts/b6/23/45/f5dfdd6e8ba0f620504858ddeb20b47f50b03d0c4b18f873f6575d2e78/PyYAML-5.4.1.tar.gz']' returned non-zero exit status 1.

  at /usr/local/lib/python3.10/subprocess.py:524 in run
       520│             # We don't call process.wait() as .__exit__ does that for us.
       521│             raise
       522│         retcode = process.poll()
       523│         if check and retcode:
    →  524│             raise CalledProcessError(retcode, process.args,
       525│                                      output=stdout, stderr=stderr)
       526│     return CompletedProcess(process.args, retcode, stdout, stderr)
       527│
       528│

The following error occurred when trying to handle this error:


  EnvCommandError

  Command ['/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10/bin/python', '-m', 'pip', 'install', '--use-pep517', '--disable-pip-version-check', '--prefix', '/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10', '--no-deps', '/root/.cache/pypoetry/artifacts/b6/23/45/f5dfdd6e8ba0f620504858ddeb20b47f50b03d0c4b18f873f6575d2e78/PyYAML-5.4.1.tar.gz'] errored with the following return code 1, and output:
  Processing /root/.cache/pypoetry/artifacts/b6/23/45/f5dfdd6e8ba0f620504858ddeb20b47f50b03d0c4b18f873f6575d2e78/PyYAML-5.4.1.tar.gz
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error

    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [62 lines of output]
        /tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
        !!

                ********************************************************************************
                The license_file parameter is deprecated, use license_files instead.

                By 2023-Oct-30, you need to update your project and remove deprecated calls
                or your builds will no longer be supported.

                See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
                ********************************************************************************

        !!
          parsed = self.parsers.get(option_name, lambda x: x)(value)
        running egg_info
        writing lib3/PyYAML.egg-info/PKG-INFO
        writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
        writing top-level names to lib3/PyYAML.egg-info/top_level.txt
        Traceback (most recent call last):
          File "/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
            main()
          File "/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
            json_out['return_val'] = hook(**hook_input['kwargs'])
          File "/root/.cache/pypoetry/virtualenvs/shynet-vUdBO1wD-py3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
            return hook(config_settings)
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
            return self._get_build_requires(config_settings, requirements=['wheel'])
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
            self.run_setup()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in run_setup
            exec(code, locals())
          File "<string>", line 271, in <module>
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 107, in setup
            return distutils.core.setup(**attrs)
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
            return run_commands(dist)
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
            dist.run_commands()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
            self.run_command(cmd)
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1234, in run_command
            super().run_command(command)
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
            cmd_obj.run()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 314, in run
            self.find_sources()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
            mm.run()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 551, in run
            self.add_defaults()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
            sdist.add_defaults(self)
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
            super().add_defaults()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
            self._add_defaults_ext()
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
            self.filelist.extend(build_ext.get_source_files())
          File "<string>", line 201, in get_source_files
          File "/tmp/pip-build-env-kg2btnsl/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.

  note: This error originates from a subprocess, and is likely not a problem with pip.


  at /usr/local/lib/python3.10/site-packages/poetry/utils/env.py:1476 in _run
      1472│                 output = subprocess.check_output(
      1473│                     command, stderr=subprocess.STDOUT, env=env, **kwargs
      1474│                 )
      1475│         except CalledProcessError as e:
    → 1476│             raise EnvCommandError(e, input=input_)
      1477│
      1478│         return decode(output)
      1479│
      1480│     def execute(self, bin: str, *args: str, **kwargs: Any) -> int:

The following error occurred when trying to handle this error:


  PoetryException

  Failed to install /root/.cache/pypoetry/artifacts/b6/23/45/f5dfdd6e8ba0f620504858ddeb20b47f50b03d0c4b18f873f6575d2e78/PyYAML-5.4.1.tar.gz

  at /usr/local/lib/python3.10/site-packages/poetry/utils/pip.py:51 in pip_install
       47│
       48│     try:
       49│         return environment.run_pip(*args)
       50│     except EnvCommandError as e:
    →  51│         raise PoetryException(f"Failed to install {path.as_posix()}") from e
```