### PR TITLE
Update Browser Icons to include DDG Mobile

### DIFF
--- a/shynet/dashboard/templatetags/helpers.py
+++ b/shynet/dashboard/templatetags/helpers.py
@@ -168,6 +168,7 @@ def iconify(text):
         "firefox mobile": "firefox.com",
         "edge mobile": "microsoft.com",
         "chromium": "chromium.org",
+        "duckduckgo mobile": "duckduckgo.com",
     }
 
     domain = None


### PR DESCRIPTION
I figured since I'm a user of the DuckDuckGo mobile app, and also run my own instance of this wonderful project, I figured that I would add the DuckDuckGo icon for browsers shown in the dashboard.
I have tested it locally on my own machine and can confirm it works.
![Screenshot_20230806-091333](https://github.com/milesmcc/shynet/assets/124477460/98212a7e-bca6-4e50-9b3c-7e40b2483664)
