### PR TITLE
Update docker build & push to use latest versions as well as push to GHCR.IO

### DIFF
--- a/.github/workflows/build-docker-edge.yml
+++ b/.github/workflows/build-docker-edge.yml
@@ -9,40 +9,50 @@ jobs:
   publish_to_docker_hub:
     runs-on: ubuntu-latest
     steps:
+      - name: Create Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            milesmcc/shynet
+            ghcr.io/milesmcc/shynet
+          tags:
+            type=edge
+
       - name: Set swap space
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 5
     
       - name: Checkout code
-        uses: actions/checkout@v2
-      
-      - name: Prepare tags
-        id: prep
-        run: |
-          DOCKER_IMAGE=milesmcc/shynet
-          TAGS="${DOCKER_IMAGE}:edge"
-          echo ::set-output name=tags::${TAGS}
-          
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push advanced image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/build-docker-manual.yml
+++ b/.github/workflows/build-docker-manual.yml
@@ -9,33 +9,42 @@ jobs:
   publish_to_docker_hub:
     runs-on: ubuntu-latest
     steps:
+      - name: Create Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            milesmcc/shynet
+            ghcr.io/milesmcc/shynet
+          tags:
+            type=raw,value=${{ github.event.inputs.tag }}
+
       - name: Set swap space
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 5
       
       - name: Checkout code
-        uses: actions/checkout@v2
-      
-      - name: Prepare tags
-        id: prep
-        run: |
-          DOCKER_IMAGE=milesmcc/shynet
-          TAGS="${DOCKER_IMAGE}:${{ github.event.inputs.tag }}"
-          echo ::set-output name=tags::${TAGS}
-          
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-        
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push advanced image
         id: docker_build
@@ -45,4 +54,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/build-docker-manual.yml
+++ b/.github/workflows/build-docker-manual.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build and push advanced image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/build-docker-release.yml
+++ b/.github/workflows/build-docker-release.yml
@@ -9,41 +9,52 @@ jobs:
   publish_to_docker_hub:
     runs-on: ubuntu-latest
     steps:
+      # https://github.com/docker/metadata-action/tree/v4/#typeref
+      - name: Create Docker Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            milesmcc/shynet
+            ghcr.io/milesmcc/shynet
+          tags:
+            type=raw,value=latest
+            type=ref,event=tag
+
       - name: Set swap space
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 5
 
       - name: Checkout code
-        uses: actions/checkout@v2
-      
-      - name: Prepare tags
-        id: prep
-        run: |
-          DOCKER_IMAGE=milesmcc/shynet
-          VERSION=${GITHUB_REF#refs/tags/}
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:latest"
-          echo ::set-output name=tags::${TAGS}
-          
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         
       - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push advanced image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
Allows users to either use the ghcr.io package manager or docker.io for their registry needs.
Updated the docker build actions to use the most recent released version as well.

Solves #284.
