### PR TITLE
feat: Add Prometheus metrics

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -687,6 +687,20 @@ files = [
 test = ["pytest"]
 
 [[package]]
+name = "django-prometheus"
+version = "2.3.1"
+description = "Django middlewares to monitor your application with Prometheus.io."
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-prometheus-2.3.1.tar.gz", hash = "sha256:f9c8b6c780c9419ea01043c63a437d79db2c33353451347894408184ad9c3e1e"},
+    {file = "django_prometheus-2.3.1-py2.py3-none-any.whl", hash = "sha256:cf9b26f7ba2e4568f08f8f91480a2882023f5908579681bcf06a4d2465f12168"},
+]
+
+[package.dependencies]
+prometheus-client = ">=0.7"
+
+[[package]]
 name = "django-redis-cache"
 version = "3.0.1"
 description = "Redis Cache Backend for Django"
@@ -1109,6 +1123,20 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "prometheus-client"
+version = "0.19.0"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "prometheus_client-0.19.0-py3-none-any.whl", hash = "sha256:c88b1e6ecf6b41cd8fb5731c7ae919bf66df6ec6fafa555cd6c0e16ca169ae92"},
+    {file = "prometheus_client-0.19.0.tar.gz", hash = "sha256:4585b0d1223148c27a225b10dbec5ae9bc4c81a99a3fa80774fa6209935324e1"},
+]
+
+[package.extras]
+twisted = ["twisted"]
 
 [[package]]
 name = "prompt-toolkit"
@@ -1749,4 +1777,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "21f01961cfb8400f3beaa3edde997911e344181bb49fb8f4040a599d0f17089b"
+content-hash = "d3e664ecac55d0d6208d50efd9c747ef24d446fc727522a938b42c8ff8623eb0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ django-npm = "^1.0.0"
 python-dotenv = "^0.18.0"
 django-debug-toolbar = "^3.2.1"
 django-cors-headers = "^3.11.0"
+django-prometheus = "^2.3.1"
 
 [tool.poetry.dev-dependencies]
 pytest-sugar = "^0.9.4"

--- a/shynet/shynet/settings.py
+++ b/shynet/shynet/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -80,6 +81,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "shynet.urls"
@@ -109,14 +111,14 @@ WSGI_APPLICATION = "shynet.wsgi.application"
 if os.getenv("SQLITE", "False") == "True":
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.sqlite3",
+            "ENGINE": "django_prometheus.db.backends.sqlite3",
             "NAME": os.environ.get("DB_NAME", "/var/local/shynet/db/db.sqlite3"),
         }
     }
 else:
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "ENGINE": "django_prometheus.db.backends.postgresql",
             "NAME": os.environ.get("DB_NAME"),
             "USER": os.environ.get("DB_USER"),
             "PASSWORD": os.environ.get("DB_PASSWORD"),
@@ -231,7 +233,7 @@ STATICFILES_FINDERS = [
 if not DEBUG and os.getenv("REDIS_CACHE_LOCATION") is not None:
     CACHES = {
         "default": {
-            "BACKEND": "redis_cache.RedisCache",
+            "BACKEND": "django_prometheus.cache.backends.redis.RedisCache",
             "LOCATION": os.getenv("REDIS_CACHE_LOCATION"),
             "KEY_PREFIX": "v1_",  # Increment when migrations occur
         }

--- a/shynet/shynet/urls.py
+++ b/shynet/shynet/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("ingress/", include(("analytics.ingress_urls", "ingress")), name="ingress"),
     path("dashboard/", include(("dashboard.urls", "dashboard"), namespace="dashboard")),
     path("healthz/", include("health_check.urls")),
+    path("prometheus/", include("django_prometheus.urls")),
     path("", include(("core.urls", "core"), namespace="core")),
     path("api/v1/", include(("api.urls", "api"), namespace="api")),
 ]


### PR DESCRIPTION
You can visit localhost/prometheus/metrics to view the metrics. Currently exposes http, db and cache metrics from [django-prometheus](https://github.com/korfuri/django-prometheus). U can also use the package to expose custom metrics relevant to shynet, but this is not done in this PR. HTTP metrics are great for insights to the shynet instance status. Dashboards that can be created from this can be previewed with the images in  [Django-mixin](https://github.com/adinhodovic/django-mixin), if you don't have a running Grafana instance.

Maybe it should be behind a flag?