### PR TITLE
escape dollarsigns for docker in .env

### DIFF
--- a/TEMPLATE.env
+++ b/TEMPLATE.env
@@ -102,7 +102,7 @@ AGGRESSIVE_HASH_SALTING=True
 #  - https://www.openstreetmap.org/?mlat=$LATITUDE&mlon=$LONGITUDE (default)
 #  - https://www.google.com/maps/search/?api=1&query=$LATITUDE,$LONGITUDE
 #  - https://www.mapquest.com/near-$LATITUDE,$LONGITUDE
-LOCATION_URL=https://www.openstreetmap.org/?mlat=$LATITUDE&mlon=$LONGITUDE
+LOCATION_URL=https://www.openstreetmap.org/?mlat=$$LATITUDE&mlon=$$LONGITUDE
 
 # How many services should be displayed on dashboard page?
 # Set to big number if you don't want pagination at all.


### PR DESCRIPTION
$LATITUDE and $LONGITUDE require additional leading dollar signs so that docker-compose doesn't interpret them as env vars and substitute in values (that don't exist).

Closes #238 