### PR TITLE
add: cache control

### DIFF
--- a/shynet/analytics/views/ingress.py
+++ b/shynet/analytics/views/ingress.py
@@ -132,7 +132,7 @@ class ScriptView(ValidateServiceOriginsMixin, View):
         dnt = self.request.META.get("HTTP_DNT", "0").strip() == "1"
         service_uuid = self.kwargs.get("service_uuid")
         service = Service.objects.get(pk=service_uuid, status=Service.ACTIVE)
-        return render(
+        response = render(
             self.request,
             "analytics/scripts/page.js",
             context=dict(
@@ -146,6 +146,9 @@ class ScriptView(ValidateServiceOriginsMixin, View):
             ),
             content_type="application/javascript",
         )
+
+        response["Cache-Control"] = "public, max-age=31536000"  # 1 year
+        return response
 
     def post(self, *args, **kwargs):
         payload = json.loads(self.request.body)


### PR DESCRIPTION
*re-open* the pr #332

# Description

Due to google analytics and page speed insights check-up, remove the warning by adding a cache policy to the header of injected script.

# Change

- [x] set cache control header with max-age of 1 year for script.js

![Screenshot from 2024-09-20 12-27-33](https://github.com/user-attachments/assets/c08b4110-e4d5-4b8a-85fa-f8946909e2ae)
