### PR TITLE
Fix stored XSS in urldisplay and iconify template filters

### DIFF
--- a/shynet/dashboard/templatetags/helpers.py
+++ b/shynet/dashboard/templatetags/helpers.py
@@ -181,7 +181,7 @@ def iconify(text):
         domain = text + ".com"
 
     return SafeString(
-        f'<span class="icon mr-1 flex-none"><img src="https://icons.duckduckgo.com/ip3/{domain}.ico"></span>'
+        f'<span class="icon mr-1 flex-none"><img src="https://icons.duckduckgo.com/ip3/{escape(domain)}.ico"></span>'
     )
 
 
@@ -190,7 +190,7 @@ def urldisplay(url):
     if url.startswith("http"):
         display_url = url.replace("http://", "").replace("https://", "")
         return SafeString(
-            f"<a href='{url}' title='{url}' rel='nofollow' class='flex items-center mr-1 truncate'>{iconify(url)}<span class='truncate'>{escape(display_url)}</span></a>"
+            f"<a href='{escape(url)}' title='{escape(url)}' rel='nofollow' class='flex items-center mr-1 truncate'>{iconify(url)}<span class='truncate'>{escape(display_url)}</span></a>"
         )
     else:
         return url


### PR DESCRIPTION
## Summary

Fixes an unauthenticated stored XSS vulnerability in the dashboard. Attacker-controlled `location` and `referrer` values submitted via the public ingress endpoint were rendered into HTML attributes without escaping, allowing JavaScript execution in the admin's session.

## Root cause

**`urldisplay`** ([helpers.py:193](../blob/master/shynet/dashboard/templatetags/helpers.py#L193)) — interpolated the raw URL into single-quoted `href='{url}'` and `title='{url}'` attributes. A payload like `http://x' onfocus='...' autofocus='` passed the `startswith("http")` check, then closed the `href` attribute early and injected new attributes.

**`iconify`** ([helpers.py:184](../blob/master/shynet/dashboard/templatetags/helpers.py#L184)) — called by `urldisplay` with the same tainted input. `urlparse().netloc` preserves quote characters, and the netloc was inserted raw into a double-quoted `src="..."` attribute.

## Fix

Apply `escape()` to the three unescaped interpolation points. This matches the existing `escape(display_url)` pattern already present on the same line. Django's `escape()` converts `'` → `&#x27;` and `"` → `&quot;`, preventing attribute break-out in both contexts.

## Affected pages

- `/dashboard/service/<uuid>/` (location and referrer tables)
- `/dashboard/service/<uuid>/locations/`