### PR TITLE
Remove wildcard ALLOWED_HOSTS default to prevent password reset poisoning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,5 @@ RUN python manage.py collectstatic --noinput && \
 # Launch
 USER appuser
 EXPOSE 8080
-HEALTHCHECK CMD bash -c 'wget -o /dev/null -O /dev/null --header "Host: ${ALLOWED_HOSTS%%,*}" "http://127.0.0.1:${PORT:-8080}/healthz/?format=json"'
+HEALTHCHECK CMD bash -c 'H="${ALLOWED_HOSTS:-localhost}"; wget -o /dev/null -O /dev/null --header "Host: ${H%%,*}" "http://127.0.0.1:${PORT:-8080}/healthz/?format=json"'
 CMD [ "./entrypoint.sh" ]

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -40,7 +40,7 @@ Before continuing, please be sure to have the latest version of Docker installed
 
     2.2 SQLite doesn't need a server, just a file. Set `SQLITE=True` in the environment file and create a Docker volume to hold the persistent DB with `docker volume create shynet_db`. Then whenever you run the container include `-v shynet_db:/var/local/shynet/db:rw` to mount the volume into the container. See the [Docker documentation on volumes](https://docs.docker.com/storage/volumes/).
 
-3. Configure an environment file for Shynet, using [this file](/TEMPLATE.env) as a template. (This file is typically named `.env`.) Make sure you set the database settings, or Shynet won't be able to run. Also consider setting `ALLOWED_HOSTS` inside the environment file to your deployment's domain for better security.
+3. Configure an environment file for Shynet, using [this file](/TEMPLATE.env) as a template. (This file is typically named `.env`.) Make sure you set the database settings, or Shynet won't be able to run. Make sure `ALLOWED_HOSTS` is set to your deployment's domain — leaving it as the `localhost` default will cause Django to reject requests to your public hostname, and setting it to `*` enables Host header injection attacks against the password reset flow.
 
 4. Launch the Shynet server for the first time by running `docker run --env-file=<your env file> milesmcc/shynet:latest`. Provided you're using the default environment information (i.e., `PERFORM_CHECKS_AND_SETUP` is `True`), you'll see a few warnings about not having an admin user or host setup; these are normal. Don't worry — we'll do this in the next step. You only need to stop if you see a stacktrace about being unable to connect to the database.
 

--- a/app.json
+++ b/app.json
@@ -79,9 +79,8 @@
       "generator": "secret"
     },
     "ALLOWED_HOSTS": {
-      "description": "Your deployment's domain (where you host, not embed, Shynet). Comma separated. The default '.herokuapp.com' allows any Heroku subdomain; add your custom domain if you have one. Do not use '*' as it enables password reset poisoning via Host header injection.",
-      "value": ".herokuapp.com",
-      "required": false
+      "description": "Your deployment's domain (where you host, not embed, Shynet), e.g. 'yourapp.herokuapp.com'. Comma separated. Do not use '*' as it enables password reset poisoning via Host header injection.",
+      "required": true
     },
     "ACCOUNT_SIGNUPS_ENABLED": {
       "description": "Set to True (capitalized) if you want people to be able to sign up for your Shynet instance (not recommended).",

--- a/app.json
+++ b/app.json
@@ -79,8 +79,8 @@
       "generator": "secret"
     },
     "ALLOWED_HOSTS": {
-      "description": "For better security, set this to your deployment's domain. (Where you will actually host, not embed, Shynet.) Set to '*' to allow serving all domains.",
-      "value": "*",
+      "description": "Your deployment's domain (where you host, not embed, Shynet). Comma separated. The default '.herokuapp.com' allows any Heroku subdomain; add your custom domain if you have one. Do not use '*' as it enables password reset poisoning via Host header injection.",
+      "value": ".herokuapp.com",
       "required": false
     },
     "ACCOUNT_SIGNUPS_ENABLED": {

--- a/kubernetes/secrets_template.yml
+++ b/kubernetes/secrets_template.yml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
     # Django settings
     DEBUG: "False"
-    ALLOWED_HOSTS: "*" # For better security, set this to your deployment's domain. Comma separated.
+    ALLOWED_HOSTS: "" # Your deployment's domain. Comma separated. Do not use "*"; it enables password reset poisoning via Host header injection.
     DJANGO_SECRET_KEY: ""
     ACCOUNT_SIGNUPS_ENABLED: "False"
     TIME_ZONE: "America/New_York"

--- a/shynet/shynet/settings.py
+++ b/shynet/shynet/settings.py
@@ -38,7 +38,9 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "onlyusethisindev")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG", "False") == "True"
 
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
+# Do not default to "*": it disables Host header validation, allowing password
+# reset poisoning (attacker-controlled reset URLs sent to users).
+ALLOWED_HOSTS = (os.getenv("ALLOWED_HOSTS") or "localhost,127.0.0.1").split(",")
 CSRF_TRUSTED_ORIGINS = filter(lambda k: len(k) > 0, os.getenv("CSRF_TRUSTED_ORIGINS", "").split(","))
 
 # Application definition


### PR DESCRIPTION
## Summary

Fixes a Host header injection vulnerability in the password reset flow. The default `ALLOWED_HOSTS = "*"` disabled Django's Host header validation, allowing an unauthenticated attacker to poison password reset emails with links to their own domain — capturing valid reset tokens when victims (or email link-preview scanners) click them.

## Root cause

`django-allauth` builds the `{{ password_reset_url }}` in reset emails using `request.build_absolute_uri()`, which derives the hostname from the `Host` header. Django's [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/stable/ref/settings/#allowed-hosts) setting is the security boundary that validates this header — but `"*"` disables it entirely.

Attack: `curl -X POST http://<shynet-ip>/accounts/password/reset/ -H "Host: attacker.com" -d "email=admin@..."` → admin receives an email linking to `http://attacker.com/accounts/password/reset/key/<valid-token>/`.

## Fix

Change the default to `localhost,127.0.0.1`. With `ALLOWED_HOSTS` properly restricted, Django's `CommonMiddleware` rejects spoofed Host headers with a 400 before any view runs — making `request.get_host()` inherently safe downstream.

| File | Change |
|---|---|
| `settings.py` | Default `*` → `localhost,127.0.0.1`. Uses `or` instead of `getenv`'s default arg so an empty-string env var falls through correctly. |
| `Dockerfile` | Healthcheck shell fallback matches the new Python default, so it still passes when the env var is unset. |
| `app.json` | Heroku one-click deploy now **requires** the user to enter their domain (no default). |
| `kubernetes/secrets_template.yml` | Removed the `*` placeholder. |
| `GUIDE.md` | Changed "consider setting" → "make sure is set", with an explicit warning about `*`. |

## Upgrade note

Existing deployments that did not set `ALLOWED_HOSTS` will need to set it after upgrading. [TEMPLATE.env](TEMPLATE.env#L30) already documented the correct value.